### PR TITLE
expose `CONFIG_PATH` from the package main file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,8 @@ export interface State {
   uplinks: ReadyUplinks[]
 }
 
+export { CONFIG_PATH } from './config'
+
 export const connect = async (ledgerEnv: LedgerEnv = LedgerEnv.Testnet) => {
   const [fileDescriptor, config] = await loadConfig()
 


### PR DESCRIPTION
So we know the correct file path being used, eg `~/.switch/config.json`.

Example:
User is presented with a `clear uplinks cache` button